### PR TITLE
add support for nested structs

### DIFF
--- a/src/main/java/net/jgp/books/spark/ch13/lab900_flat_json_invoice/FlattenJsonApp.java
+++ b/src/main/java/net/jgp/books/spark/ch13/lab900_flat_json_invoice/FlattenJsonApp.java
@@ -82,11 +82,10 @@ public class FlattenJsonApp {
           break;
         case STRUCT_TYPE:
           // Mapping
-          String ddl[] = field.toDDL().split("`"); // fragile :(
-          for (int i = 3; i < ddl.length; i += 2) {
-            processedDf = processedDf.withColumn(
-                field.name() + "_" + ddl[i],
-                processedDf.col(field.name() + "." + ddl[i]));
+          StructField[] structFields = ((StructType) field.dataType()).fields();
+          for (StructField structField : structFields) {
+            processedDf = processedDf.withColumn(field.name() + "_" + structField.name(),
+                processedDf.col(field.name() + "." + structField.name()));
           }
           processedDf = processedDf
               .drop(field.name());


### PR DESCRIPTION
The provided code does not support nested structs. For example for the following json documents 
```
{
  "date": "2019-10-05",
  "info": {
    "publisher": {
      "name": "Manning Publications",
      "city": "Shelter Island",
      "state": "New York",
      "country": "USA"
    },
    "author": {
      "name": "Jean Georges Perrin",
      "city": "Chapel Hill",
      "state": "North Carolina",
      "country": "USA"
    }
  },
  "books": [
    {
      "title": "Spark with Java",
      "salesByMonth": [10, 25, 30, 45, 80, 6]
    },
    {
      "title": "Spark in Action, 2nd Edition",
      "salesByMonth": [11, 24, 33, 48, 800, 126]
    },
    {
      "title": "Spark in Action, 1st Edition",
      "salesByMonth": [31, 124, 333, 418, 60, 122]
    }
  ]
}
```
it fails to flatten the schema with the following error: 
```
Exception in thread "main" org.apache.spark.sql.AnalysisException: No such struct field city in author, publisher;
	at org.apache.spark.sql.catalyst.expressions.ExtractValue$.findField(complexTypeExtractors.scala:85)
	at org.apache.spark.sql.catalyst.expressions.ExtractValue$.apply(complexTypeExtractors.scala:53)
	at org.apache.spark.sql.catalyst.expressions.package$AttributeSeq.$anonfun$resolve$1(package.scala:348)
	at scala.collection.IndexedSeqOptimized.foldLeft(IndexedSeqOptimized.scala:60)
	at scala.collection.IndexedSeqOptimized.foldLeft$(IndexedSeqOptimized.scala:68)
	at scala.collection.mutable.ArrayBuffer.foldLeft(ArrayBuffer.scala:49)
	at org.apache.spark.sql.catalyst.expressions.package$AttributeSeq.resolve(package.scala:347)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveQuoted(LogicalPlan.scala:121)
	at org.apache.spark.sql.Dataset.resolve(Dataset.scala:262)
	at org.apache.spark.sql.Dataset.col(Dataset.scala:1353)
	at net.jgp.books.spark.ch13.lab900_flat_json_invoice.FlattenJsonApp.flattenNestedStructure(FlattenJsonApp.java:89)
	at net.jgp.books.spark.ch13.lab900_flat_json_invoice.FlattenJsonApp.start(FlattenJsonApp.java:50)
	at net.jgp.books.spark.ch13.lab900_flat_json_invoice.FlattenJsonApp.main(FlattenJsonApp.java:27)

```